### PR TITLE
Allow bedrock to be cheated in by default

### DIFF
--- a/src/codechicken/nei/NEIServerConfig.java
+++ b/src/codechicken/nei/NEIServerConfig.java
@@ -181,7 +181,7 @@ public class NEIServerConfig
         bannedItems.clear();
         File file = new File(saveDir, "banneditems.cfg");
         if(!file.exists()) {
-            bannedItems.put(new ItemStack(Blocks.bedrock), new HashSet<String>(Arrays.asList("NONE")));
+            bannedItems.put(new ItemStack(Blocks.command_block), new HashSet<String>(Arrays.asList("NONE")));
             saveBannedItems();
             return;
         }


### PR DESCRIPTION
Some mods actually use it so I think allowing it to be cheated in by default is a good idea.
In the mean time, command blocks shouldn't since they are strictly admin only.
