### PR TITLE
Fix rare NPE when throwing all items

### DIFF
--- a/src/codechicken/nei/FastTransferManager.java
+++ b/src/codechicken/nei/FastTransferManager.java
@@ -324,6 +324,8 @@ public class FastTransferManager
         clickSlot(window, -999);
 
         generateSlotMap(window.inventorySlots, held);
+        if (slotZones == null || slotZoneMap == null)
+            return;
         for (int slotIndex : slotZones.get(slotZoneMap.get(pickedUpFromSlot))) {
             Slot slot = window.inventorySlots.getSlot(slotIndex);
             if (areStacksSameType(held, slot.getStack())) {


### PR DESCRIPTION
This appears to be a rare corner case situation that happens mostly when there is lag between the server and the client. Addresses Issue #62.
