### PR TITLE
removes dependency on server world name leading to NPE; fixes #247

### DIFF
--- a/src/codechicken/nei/NEICPH.java
+++ b/src/codechicken/nei/NEICPH.java
@@ -115,10 +115,13 @@ public class NEICPH implements IClientPacketHandler
     }
 
     private static String getSaveName(String worldName) {
-        if (Minecraft.getMinecraft().isSingleplayer())
+        if (Minecraft.getMinecraft().isSingleplayer()) {
             return "local/" + ClientUtils.getWorldSaveName();
-
-        return "remote/" + ClientUtils.getServerIP().replace(':', '~') + "/" + worldName;
+        } else {
+            // The server's world name is untrusted input; we can't create a
+            // path using the name sent from the server, so just default it.
+            return "remote/" + ClientUtils.getServerIP().replace(':', '~') + "/world";
+        }
     }
 
     public static void sendGiveItem(ItemStack spawnstack, boolean infinite, boolean doSpawn) {

--- a/src/codechicken/nei/NEIClientConfig.java
+++ b/src/codechicken/nei/NEIClientConfig.java
@@ -212,7 +212,14 @@ public class NEIClientConfig
         if (newWorld)
             saveDir.mkdirs();
 
-        world = new ConfigSet(new File(saveDir, "NEI.dat"), new ConfigFile(new File(saveDir, "NEI.cfg")));
+        try {
+          world = new ConfigSet(new File(saveDir, "NEI.dat"), new ConfigFile(new File(saveDir, "NEI.cfg")));
+        } catch (Exception e) {
+          // I'd kill the process here, but not sure how - exceptions are out
+          // there is a catch-all-and-swallow handler between here and there.
+          NEIClientConfig.logger.error("Failed to load NEI configuration; the process is going to die with an NPE later on.", e);
+        }
+
         onWorldLoad(newWorld);
     }
 


### PR DESCRIPTION
It is possible to construct a server's world name in such a way as to cause `NEIClientConfig.loadWorld` to raise an IOException and leave the `world` variable set to null.  Unfortunately, the `loadWorld` callsite is wrapped in a catch-and-swallow style exception handler which causes the `world != null` invariant to be violated; the bug is ultimately revealed as an NPE during `renderSlotOverlay`.

For example, the server-sent world name `../../var/lib/minecraft/world` results in a malformed `saves/NEI` folder that lacks a `remote/HOST~PORT` folder.

The fix is to remove this dependency on the server world name, and use a hard-coded name instead.  This ought to be safe because a HOST:PORT combination should uniquely identify a world, *but this assumption should be reviewed*.

I've also added some logging around the assignment of the `world` variable, so that it will log a more helpful error message if NEI is unable to create this variable in the future for some other reason.