### PR TITLE
Set ingredient NBT when looking up by ingredient

### DIFF
--- a/src/codechicken/nei/recipe/TemplateRecipeHandler.java
+++ b/src/codechicken/nei/recipe/TemplateRecipeHandler.java
@@ -117,6 +117,9 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
                     if (NEIServerUtils.areStacksSameTypeCrafting(ingredient, stack.items[i])) {
                         stack.item = stack.items[i];
                         stack.item.setItemDamage(ingredient.getItemDamage());
+                        if (ingredient.hasTagCompound()) {
+                            stack.item.setTagCompound((NBTTagCompound) ingredient.getTagCompound().copy());
+                        }
                         stack.items = new ItemStack[]{stack.item};
                         stack.setPermutationToRender(0);
                         break;


### PR DESCRIPTION
Forestry 4.0 has wood items whose type depends on NBT.
If we look up what Ebony planks can make (any vanilla wood plank recipe) we get the correct recipes, but the selected crafting ingredient is the default Larch planks instead of Ebony because the NBT is not set.