### PR TITLE
Create issue template to redirect people to TheCBProject

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,2 @@
+For Minecraft 1.9+ this project has moved, please submit bug reports here instead:  
+https://github.com/TheCBProject/NotEnoughItems/issues


### PR DESCRIPTION
This issue template will show up in the submission box when people try to submit an issue here.
It should help with the confusion between the two projects.
